### PR TITLE
Supports objects which a property access may fail

### DIFF
--- a/objbrowser/objectbrowser.py
+++ b/objbrowser/objectbrowser.py
@@ -50,6 +50,7 @@ class ObjectBrowser(QtWidgets.QMainWindow):
                  show_special_attributes = None,  # None uses value from QSettings
                  auto_refresh=None,  # None uses value from QSettings
                  refresh_rate=None,  # None uses value from QSettings
+                 fail_silently=None,
                  reset = False):
         """ Constructor
         
@@ -83,11 +84,11 @@ class ObjectBrowser(QtWidgets.QMainWindow):
                                     show_callable_attributes= show_callable_attributes,
                                     show_special_attributes = show_special_attributes)
 
-        self._tree_model = TreeModel(obj, name, attr_cols = self._attr_cols)
+        self._tree_model = TreeModel(obj, name, attr_cols = self._attr_cols, fail_silently = fail_silently)
             
         self._proxy_tree_model = TreeProxyModel(
-            show_callable_attributes= show_callable_attributes,
-            show_special_attributes = show_special_attributes)
+            show_callable_attributes=show_callable_attributes,
+            show_special_attributes=show_special_attributes)
         
         self._proxy_tree_model.setSourceModel(self._tree_model)
         #self._proxy_tree_model.setSortRole(RegistryTableModel.SORT_ROLE)


### PR DESCRIPTION
If fail_silently flag is set, reclasses obj temporarilly before calling
inspect.getmembers(obj). This reclassing overrides __getattribute__ to
return a default InvalidProperty object in case of exception.

Change-Id: Id9d2363c7676241ee1eef6282afaa549e836e485